### PR TITLE
Fix UserProfileSchema validation errors in profile edit form

### DIFF
--- a/src/routes/_auth/profile/edit.tsx
+++ b/src/routes/_auth/profile/edit.tsx
@@ -29,8 +29,12 @@ export const ProfileForm = () => {
 
 	const form = useForm({
 		validators: {
-			onChange: (values) => {
-				UserProfileSchema.parse(values.value);
+			onChange: ({ value }) => {
+				const result = UserProfileSchema.safeParse(value);
+				if (!result.success) {
+					return result.error.issues.map((i) => i.message).join(", ");
+				}
+				return undefined;
 			},
 		},
 		defaultValues: userProfile,

--- a/src/types.ts
+++ b/src/types.ts
@@ -664,7 +664,7 @@ export const BrandSchema = z.string();
 const StateEnum = z.nativeEnum(States);
 
 const AddressSchema = z.object({
-	id: z.string(),
+	id: z.string().optional(),
 	street1: z.string(),
 	street2: z.string().nullable().optional(),
 	city: z.string(),
@@ -676,13 +676,17 @@ export const UserProfileSchema = z.object({
 	firstName: z.string().nullable().optional(),
 	lastName: z.string().nullable().optional(),
 	dateOfBirth: z
-		.string()
-		.transform((str) => (str ? new Date(str) : null))
+		.union([z.string(), z.date()])
+		.transform((val) => {
+			if (val instanceof Date) return val;
+			return val ? new Date(val) : null;
+		})
+		.nullable()
 		.optional(),
 	phoneNumber: z.string().nullable().optional(),
 	acceptedTerms: z.boolean(),
-	billingAddress: AddressSchema.optional(),
-	shippingAddress: AddressSchema.optional(),
+	billingAddress: AddressSchema.nullable().optional(),
+	shippingAddress: AddressSchema.nullable().optional(),
 	canContact: z.boolean().optional(),
 	userId: z.string(),
 });


### PR DESCRIPTION
## Summary
- Accept both string and Date for dateOfBirth field
- Make billingAddress.id optional for new addresses  
- Allow null values for shippingAddress
- Use safeParse instead of parse to return errors properly

Fixes ZodError occurring when users edit their profile with null/undefined address fields.

## Test plan
- [x] Edit profile with no shipping address set
- [x] Edit profile with existing addresses
- [x] Verify date of birth field works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)